### PR TITLE
Fix pygit2 deprecations

### DIFF
--- a/bot/cogs/meta.py
+++ b/bot/cogs/meta.py
@@ -27,7 +27,7 @@ class Meta(commands.Cog):
 
     def format_commit(self, commit: pygit2.Commit) -> str:
         short, _, _ = commit.message.partition("\n")
-        short_sha2 = commit.hex[0:6]
+        short_sha2 = str(commit.id)[0:6]
         commit_tz = datetime.timezone(
             datetime.timedelta(minutes=commit.commit_time_offset)
         )
@@ -37,10 +37,11 @@ class Meta(commands.Cog):
 
         # [`hash`](url) message (offset)
         offset = format_dt(commit_time.astimezone(datetime.timezone.utc), "R")
-        return f"[`{short_sha2}`](https://github.com/No767/Catherine-Chan/commit/{commit.hex}) {short} ({offset})"
+        commit_id = str(commit.id)
+        return f"[`{short_sha2}`](https://github.com/No767/Catherine-Chan/commit/{commit_id}) {short} ({offset})"
 
     def get_last_commits(self, count: int = 5):
-        repo = pygit2.Repository(".git")  # type: ignore
+        repo = pygit2.Repository(".git")
         commits = list(
             itertools.islice(repo.walk(repo.head.target, SortMode.TOPOLOGICAL), count)
         )


### PR DESCRIPTION
# Summary

Around an month ago, pygit2 released 1.15.0, which included [plenty of deprecations and breaking changes](https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md#1150-2024-05-18). One of them namely is the removal of `oid.hex`, which of course, caused an issue with pyright and thus resulting to this PR.

## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR