### PR TITLE
Rewrite Prometheus metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.11
+    python: python3
 files: '.py'
 exclude: ".env,.yml,.gitignore,.git,.md,.txt"
 default_stages: [push, commit]

--- a/bot/catherinecore.py
+++ b/bot/catherinecore.py
@@ -43,6 +43,7 @@ class Catherine(commands.Bot):
         self._dev_mode = config.bot.get("dev_mode", False)
         self._reloader = Reloader(self, Path(__file__).parent)
         self._prometheus = config.bot.get("prometheus", {})
+        self._prometheus_enabled = self._prometheus.get("enabled", False)
 
     # Basically silence all prefixed errors
     async def on_command_error(
@@ -59,7 +60,7 @@ class Catherine(commands.Bot):
 
         await self.load_extension("jishaku")
 
-        if self._prometheus.get("enabled", False):
+        if self._prometheus_enabled:
             await self.load_extension("cogs.ext.prometheus")
             prom_host = self._prometheus.get("host", "127.0.0.1")
             prom_port = self._prometheus.get("port", 6789)
@@ -76,9 +77,7 @@ class Catherine(commands.Bot):
         if not hasattr(self, "uptime"):
             self.uptime = discord.utils.utcnow()
 
-        if self._prometheus.get("enabled", False) and not hasattr(
-            self, "guild_metrics_created"
-        ):
+        if self._prometheus_enabled and not hasattr(self, "guild_metrics_created"):
             self.guild_metrics_created = self.metrics.guilds.fill()
 
         curr_user = None if self.user is None else self.user.name

--- a/bot/catherinecore.py
+++ b/bot/catherinecore.py
@@ -11,7 +11,6 @@ from libs.ui.pronouns import ApprovePronounsExampleView
 from libs.utils.config import CatherineConfig
 from libs.utils.reloader import Reloader
 from libs.utils.tree import CatherineCommandTree
-from prometheus_async.aio.web import start_http_server
 
 
 class Catherine(commands.Bot):
@@ -37,14 +36,13 @@ class Catherine(commands.Bot):
             **kwargs,
         )
         self.logger: logging.Logger = logging.getLogger("catherine")
-        self.metrics = prometheus.create_gauges(self)
+        self.metrics = prometheus.MetricCollector(self)
         self.session = session
         self.pool = pool
         self.version = str(VERSION)
         self._dev_mode = config.bot.get("dev_mode", False)
         self._reloader = Reloader(self, Path(__file__).parent)
         self._prometheus = config.bot.get("prometheus", {})
-        self._prometheus_enabled = self._prometheus.get("enabled", False)
 
     # Basically silence all prefixed errors
     async def on_command_error(
@@ -61,15 +59,15 @@ class Catherine(commands.Bot):
 
         await self.load_extension("jishaku")
 
-        if self._prometheus_enabled:
+        if self._prometheus.get("enabled", False):
             await self.load_extension("cogs.ext.prometheus")
             prom_host = self._prometheus.get("host", "127.0.0.1")
             prom_port = self._prometheus.get("port", 6789)
 
-            await start_http_server(addr=prom_host, port=prom_port)
+            await self.metrics.start(host=prom_host, port=prom_port)
             self.logger.info("Prometheus Server started on %s:%s", prom_host, prom_port)
 
-            self.metrics.fill_gauges()
+            self.metrics.fill()
 
         if self._dev_mode:
             self._reloader.start()
@@ -77,8 +75,9 @@ class Catherine(commands.Bot):
     async def on_ready(self):
         if not hasattr(self, "uptime"):
             self.uptime = discord.utils.utcnow()
-        elif self._prometheus_enabled and not hasattr(self, "guild_metrics_created"):
-            self.guild_metrics_created = self.metrics.create_guild_gauges()
+        
+        if self._prometheus.get("enabled", False) and not hasattr(self, "guild_metrics_created"):
+            self.guild_metrics_created = self.metrics.guilds.fill()
 
         curr_user = None if self.user is None else self.user.name
         self.logger.info(f"{curr_user} is fully ready!")

--- a/bot/catherinecore.py
+++ b/bot/catherinecore.py
@@ -75,8 +75,10 @@ class Catherine(commands.Bot):
     async def on_ready(self):
         if not hasattr(self, "uptime"):
             self.uptime = discord.utils.utcnow()
-        
-        if self._prometheus.get("enabled", False) and not hasattr(self, "guild_metrics_created"):
+
+        if self._prometheus.get("enabled", False) and not hasattr(
+            self, "guild_metrics_created"
+        ):
             self.guild_metrics_created = self.metrics.guilds.fill()
 
         curr_user = None if self.user is None else self.user.name

--- a/bot/cogs/blacklist.py
+++ b/bot/cogs/blacklist.py
@@ -44,7 +44,7 @@ class Blacklist(commands.Cog, command_attrs=dict(hidden=True)):
         """
         await self.pool.execute(query, given_id, True)
         get_blacklist.cache_invalidate(given_id, self.pool)
-        self.bot.metrics.blacklisted_users.inc()
+        self.bot.metrics.blacklist.users.inc()
         await ctx.send(f"Done. Added ID {given_id} to the blacklist")
 
     @blacklist.command(name="remove")
@@ -57,7 +57,7 @@ class Blacklist(commands.Cog, command_attrs=dict(hidden=True)):
         """
         await self.pool.execute(query, given_id)
         get_blacklist.cache_invalidate(given_id, self.pool)
-        self.bot.metrics.blacklisted_users.dec()
+        self.bot.metrics.blacklist.users.dec()
         await ctx.send(f"Done. Removed ID {given_id} from the blacklist")
 
 

--- a/bot/cogs/ext/prometheus.py
+++ b/bot/cogs/ext/prometheus.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
 import platform
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, NamedTuple
 
 import discord
 import msgspec
 from discord import app_commands
 from discord.ext import commands, tasks
-from prometheus_client import Counter, Gauge, Info
+
+
+try:
+
+    from prometheus_async.aio.web import start_http_server
+    from prometheus_client import Counter, Enum, Gauge, Info, Summary
+except ImportError:
+    raise RuntimeError(
+        "Prometheus libraries are required to be installed. "
+        "Either install those libraries or disable Prometheus extension"
+    )
+
 
 if TYPE_CHECKING:
     from bot.catherinecore import Catherine
@@ -16,93 +27,27 @@ if TYPE_CHECKING:
 METRIC_PREFIX = "discord_"
 
 
-def create_gauges(bot: Catherine) -> "Metrics":
-    return Metrics(
-        bot=bot,
-        connection_gauge=Gauge(
-            f"{METRIC_PREFIX}connected",
-            "Determines if the bot is connected to Discord",
-            ["shard"],
-        ),
-        latency_gauge=Gauge(
-            f"{METRIC_PREFIX}latency",
-            "latency to Discord",
-            ["shard"],
-        ),
-        on_app_command_counter=Counter(
-            f"{METRIC_PREFIX}on_app_command",
-            "Amount of slash commands called by users",
-        ),
-        guild_gauge=Gauge(
-            f"{METRIC_PREFIX}stat_total_guilds",
-            "Amount of guilds this bot is in",
-        ),
-        text_channel_gauge=Gauge(
-            f"{METRIC_PREFIX}stat_total_text_channels",
-            "Amount of text channels this bot is has access to",
-        ),
-        voice_channel_gauge=Gauge(
-            f"{METRIC_PREFIX}stat_total_voice_channels",
-            "Amount of voice channels this bot is has access to",
-        ),
-        user_gauge=Gauge(
-            f"{METRIC_PREFIX}stat_total_users", "Amount of users this bot can see"
-        ),
-        user_unique_gauge=Gauge(
-            f"{METRIC_PREFIX}stat_total_unique_users",
-            "Amount of unique users this bot can see",
-        ),
-        commands_gauge=Gauge(
-            f"{METRIC_PREFIX}stat_app_total_commands", "Amount of commands"
-        ),
-        pronouns_tester_counter=Counter(
-            f"{METRIC_PREFIX}pronouns_tester",
-            "Amount of successful pronouns tested",
-        ),
-        version_info=Info(
-            "version_info", "Catherine-Chan's current version and other version info"
-        ),
-        attempted_commands=Counter(
-            f"{METRIC_PREFIX}attempted_commands",
-            "Amount of attempted commands ran by blacklisted users",
-        ),
-        blacklisted_users=Gauge(
-            f"{METRIC_PREFIX}blacklisted_users", "Number of blacklisted users"
-        ),
-    )
-
-
-class GuildMetrics(TypedDict):
+class GuildCount(NamedTuple):
+    count: int
     text: int
     voice: int
-    guilds: int
-    total_commands: int
-
-
-class MemberCounts(msgspec.Struct):
-    total: int = 0
-    unique: int = 0
-
-
-class Metrics(msgspec.Struct, frozen=True):
-    bot: Catherine
-    connection_gauge: Gauge
-    latency_gauge: Gauge
-    on_app_command_counter: Counter
-    guild_gauge: Gauge
-    text_channel_gauge: Gauge
-    voice_channel_gauge: Gauge
-    user_gauge: Gauge
-    user_unique_gauge: Gauge
-    commands_gauge: Gauge
-    version_info: Info
-    attempted_commands: Counter
-    blacklisted_users: Gauge
-    pronouns_tester_counter: Counter
-
-    def get_stats(self) -> GuildMetrics:
-        # The same way R. Danny does it
-        total_commands = 0
+    users: int
+    
+class GuildCollector:
+    __slots__ = ("bot", "count", "text", "voice", "users")
+    
+    def __init__(self, bot: Catherine):
+        self.bot = bot
+        self.count = Gauge(f"{METRIC_PREFIX}guilds", "Amount of guilds connected")
+        self.text = Gauge(f"{METRIC_PREFIX}text", "Amount of text channels that can be seen")
+        self.voice = Gauge(f"{METRIC_PREFIX}voice", "Amount of voice channels")
+        self.users = Gauge(f"{METRIC_PREFIX}users", "Total users")
+        
+        # self.fill()
+        
+        
+    def _get_stats(self) -> GuildCount:
+        users = len(self.bot.users)
         text = 0
         voice = 0
         guilds = 0
@@ -115,46 +60,96 @@ class Metrics(msgspec.Struct, frozen=True):
                     text += 1
                 elif isinstance(channel, discord.VoiceChannel):
                     voice += 1
-
-        for cmd in self.bot.tree.walk_commands():
-            if isinstance(cmd, app_commands.commands.Command):
-                total_commands += 1
-
-        return GuildMetrics(
+                    
+        return GuildCount(
+            count=guilds,
             text=text,
             voice=voice,
-            guilds=guilds,
-            total_commands=total_commands,
+            users=users
         )
+                    
+    def fill(self) -> None:
+        stats = self._get_stats()
+        
+        self.count.set(stats.count)
+        self.text.set(stats.text)
+        self.voice.set(stats.voice)
+        self.users.set(stats.users)
 
-    def create_guild_gauges(self) -> None:
-        stats = self.get_stats()
+class BlacklistCollector:
+    __slots__ = ("bot", "users", "commands")
+    
+    def __init__(self, bot: Catherine):
+        self.bot = bot
+        
+        # For now, until we can improve the blacklist system,
+        # we will leave these to be blank
+        self.users = Gauge(f"{METRIC_PREFIX}blacklist_users", "Current amount of blacklisted users")
+        self.commands = Counter(f"{METRIC_PREFIX}blacklist_commands", "Counter of commands that were attempted for blacklisted users")
+        
+        
+    
+class FeatureCollector:
+    __slots__ = ("bot", "successful_pronouns")
+    
+    def __init__(self, bot: Catherine):
+        self.bot = bot
+        self.successful_pronouns = Counter(f"{METRIC_PREFIX}successful_pronouns", "Counter of successful pronouns tester invocations")
+        
+class CommandsCollector:
+    __slots__ = ("bot", "total", "invocation", "count")
+    
+    def __init__(self, bot: Catherine):
+        self.bot = bot
+        
+        self.total = Summary(f"{METRIC_PREFIX}commands_total", "Total commands included")
+        self.invocation = Counter(f"{METRIC_PREFIX}commands_invocation", "Counter for invoked commands")
+        self.count = Counter(f"{METRIC_PREFIX}commands_count", "Individual count for commands", ["commands"])
+        
+    def fill(self, amount: int) -> None:
+        self.total.observe(amount)
 
-        self.guild_gauge.set(stats["guilds"])
-        self.text_channel_gauge.set(stats["text"])
-        self.voice_channel_gauge.set(stats["voice"])
-
-    def fill_gauges(self):
-        stats = self.get_stats()
-
-        self.blacklisted_users.set(0)
-        self.attempted_commands.inc(0)
-        self.version_info.info(
+class MetricCollector:
+    __slots__ = ("bot", "connected", "latency", "commands", "version", "guilds", "blacklist", "features")
+    
+    def __init__(self, bot: Catherine):
+        self.bot = bot
+        
+        self.connected = Enum(
+            f"{METRIC_PREFIX}connected",
+            "Connected to Discord",
+            ["shard"],
+            states=["connected", "disconnected"],
+        )
+        self.latency = Gauge(f"{METRIC_PREFIX}latency", "Latency to Discord", ["shard"])
+        self.version = Info(f"{METRIC_PREFIX}version", "Versions of the bot")
+        self.commands = CommandsCollector(bot)
+        self.guilds = GuildCollector(bot)
+        self.blacklist = BlacklistCollector(bot)
+        self.features = FeatureCollector(bot)
+        
+        
+    def _get_commands(self) -> int:
+        total = 0
+        
+        for command in self.bot.tree.walk_commands():
+            if isinstance(command, (app_commands.Command)):
+                total += 1
+                
+        return total
+    
+    def fill(self) -> None:
+        self.version.info(
             {
                 "build_version": self.bot.version,
                 "dpy_version": discord.__version__,
                 "python_version": platform.python_version(),
             }
         )
-        self.commands_gauge.set(stats["total_commands"])
-        self.on_app_command_counter.inc(0)
-        self.pronouns_tester_counter.inc(0)
-
-        if self.bot.is_closed():
-            self.connection_gauge.labels(None).set(0)
-            return
-
-        self.connection_gauge.labels(None).set(1)
+        self.commands.fill(self._get_commands())
+        
+    async def start(self, host: str, port: int) -> None:
+        await start_http_server(addr=host, port=port)
 
 
 class Prometheus(commands.Cog):
@@ -162,67 +157,35 @@ class Prometheus(commands.Cog):
 
     def __init__(self, bot: Catherine) -> None:
         self.bot = bot
-        self._prev_member_count = MemberCounts()
-        self.members = self._obtain_member_count()
-
-    def _obtain_member_count(self) -> MemberCounts:
-        total_members = 0
-        unique_members = len(self.bot.users)
-
-        for guild in self.bot.guilds:
-            if guild.unavailable:
-                continue
-            total_members += guild.member_count or 0
-
-        return MemberCounts(total=total_members, unique=unique_members)
-
-    def _update_member_count(self) -> None:
-        members = self._obtain_member_count()
-        temp = self.members
-
-        temp.total = members.total
-        temp.unique = members.unique
-
-        self.members = temp
-        self.bot.metrics.user_gauge.set(self.members.total)
-        self.bot.metrics.user_unique_gauge.set(self.members.unique)
+        self._connected_label = self.bot.metrics.connected.labels(None)
 
     async def cog_load(self) -> None:
         # For some reason it would only work inside here
         self.latency_loop.start()
-        self.member_loop.start()
 
     async def cog_unload(self) -> None:
         self.latency_loop.stop()
-        self.member_loop.stop()
 
     @tasks.loop(seconds=5)
     async def latency_loop(self) -> None:
-        self.bot.metrics.latency_gauge.labels(None).set(self.bot.latency)
+        self.bot.metrics.latency.labels(None).set(self.bot.latency)
 
-    @tasks.loop(seconds=10)
-    async def member_loop(self) -> None:
-        self._update_member_count()
 
     @commands.Cog.listener()
     async def on_connect(self) -> None:
-        self.bot.metrics.connection_gauge.labels(None).set(1)
-
-    @commands.Cog.listener()
-    async def on_resumed(self) -> None:
-        self.bot.metrics.connection_gauge.labels(None).set(1)
+        self._connected_label.state("connected")
 
     @commands.Cog.listener()
     async def on_disconnect(self) -> None:
-        self.bot.metrics.connection_gauge.labels(None).set(0)
+        self._connected_label.state("disconnected")
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild) -> None:
-        self.bot.metrics.create_guild_gauges()
+        self.bot.metrics.guilds.fill()
 
     @commands.Cog.listener()
     async def on_guild_remove(self, guild: discord.Guild) -> None:
-        self.bot.metrics.create_guild_gauges()
+        self.bot.metrics.guilds.fill()
 
 
 async def setup(bot: Catherine) -> None:

--- a/bot/libs/ui/pronouns/modals.py
+++ b/bot/libs/ui/pronouns/modals.py
@@ -11,7 +11,7 @@ from libs.cog_utils.pronouns import (
 from libs.utils import CatherineModal
 
 if TYPE_CHECKING:
-    from bot.cogs.ext.prometheus import Metrics
+    from bot.cogs.ext.prometheus import MetricCollector
 
 
 class PronounsTesterModal(CatherineModal, title="Input the fields"):
@@ -20,7 +20,7 @@ class PronounsTesterModal(CatherineModal, title="Input the fields"):
         interaction: discord.Interaction,
         sentence: str,
         name: str,
-        metrics: Metrics,
+        metrics: MetricCollector,
     ):
         super().__init__(interaction=interaction)
         self.sentence = sentence
@@ -52,7 +52,6 @@ class PronounsTesterModal(CatherineModal, title="Input the fields"):
     async def on_submit(self, interaction: discord.Interaction) -> None:
         # The new Regex-based solution to the pronouns tester command
         # Original: https://github.com/LilbabxJJ-1/PrideBot/blob/master/commands/pronouns.py#L15
-        self.metrics.pronouns_tester_counter.inc()
         replacements = {
             "$subjective_pronoun": self.sp.value.lower(),
             "$objective_pronoun": self.op.value.lower(),
@@ -63,4 +62,5 @@ class PronounsTesterModal(CatherineModal, title="Input the fields"):
         }
         parsed_sentence = parse_pronouns_sentence(replacements, self.sentence)
         complete_sentence = convert_to_proper_sentence(parsed_sentence)
+        self.metrics.features.successful_pronouns.inc()
         await interaction.response.send_message(complete_sentence)

--- a/bot/libs/utils/tree.py
+++ b/bot/libs/utils/tree.py
@@ -10,6 +10,7 @@ from discord.app_commands import (
     CommandTree,
     MissingPermissions,
     NoPrivateMessage,
+    ContextMenu
 )
 from discord.utils import utcnow
 
@@ -59,15 +60,26 @@ def _build_missing_perm_embed(
 # At the very least better than Jade's on_interaction checks
 # https://github.com/LilbabxJJ-1/PrideBot/blob/master/main.py#L19-L36
 class CatherineCommandTree(CommandTree):
+            
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         bot: Catherine = interaction.client  # type: ignore # Pretty much returns the subclass anyways. I checked - Noelle
-        bot.metrics.on_app_command_counter.inc()
+        
+        # TODO: Also check for blacklists here
+        bot.metrics.commands.invocation.inc()
+        # TODO: Need to skip whether this user is blacklisted or not
+        if interaction.command:
+            name = interaction.command.name
+            bot.metrics.commands.count.labels(name).inc()
+        
         if (
             bot.owner_id == interaction.user.id
             or bot.application_id == interaction.user.id
         ):
             return True
-
+        
+            
+            
+        
         blacklist = await get_blacklist(interaction.user.id, bot.pool)
 
         # Two conditions must pass here:
@@ -78,11 +90,13 @@ class CatherineCommandTree(CommandTree):
             blacklist.blacklist_status is not None
             and blacklist.blacklist_status is True
         ):
-            bot.metrics.attempted_commands.inc(1)
+            bot.metrics.blacklist.commands.inc(1)
             await interaction.response.send_message(
                 f"My fellow user, {interaction.user.mention}, you just got the L. You are blacklisted from using this bot. Take an \U0001f1f1, \U0001f1f1oser. [Here is your appeal form](https://media.tenor.com/K9R9beOgPR4AAAAC/fortnite-thanos.gif)"
             )
             return False
+        
+            
         return True
 
     async def on_error(

--- a/bot/libs/utils/tree.py
+++ b/bot/libs/utils/tree.py
@@ -10,7 +10,6 @@ from discord.app_commands import (
     CommandTree,
     MissingPermissions,
     NoPrivateMessage,
-    ContextMenu
 )
 from discord.utils import utcnow
 
@@ -60,26 +59,23 @@ def _build_missing_perm_embed(
 # At the very least better than Jade's on_interaction checks
 # https://github.com/LilbabxJJ-1/PrideBot/blob/master/main.py#L19-L36
 class CatherineCommandTree(CommandTree):
-            
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         bot: Catherine = interaction.client  # type: ignore # Pretty much returns the subclass anyways. I checked - Noelle
-        
+
         # TODO: Also check for blacklists here
         bot.metrics.commands.invocation.inc()
         # TODO: Need to skip whether this user is blacklisted or not
         if interaction.command:
             name = interaction.command.name
             bot.metrics.commands.count.labels(name).inc()
-        
+
         if (
             bot.owner_id == interaction.user.id
             or bot.application_id == interaction.user.id
         ):
             return True
-        
-            
-            
-        
+
         blacklist = await get_blacklist(interaction.user.id, bot.pool)
 
         # Two conditions must pass here:
@@ -95,8 +91,7 @@ class CatherineCommandTree(CommandTree):
                 f"My fellow user, {interaction.user.mention}, you just got the L. You are blacklisted from using this bot. Take an \U0001f1f1, \U0001f1f1oser. [Here is your appeal form](https://media.tenor.com/K9R9beOgPR4AAAAC/fortnite-thanos.gif)"
             )
             return False
-        
-            
+
         return True
 
     async def on_error(


### PR DESCRIPTION
# Summary

This PR focuses on completely rewriting the Prometheus metrics to collect data in an more stable and improved method. The collectors are now split up, making it easier to debug and manage. In addition, an new metric, `discord_commands_count`, which has an label to count each individual command, is added. This makes it much easier to find what commands are used the most and to make an informed decision on it.

**This PR breaks the entire Grafana dashboard associated with these metrics**

## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR