### PR TITLE
Fix inaccurate member counts with Prometheus 

### DIFF
--- a/bot/cogs/ext/prometheus.py
+++ b/bot/cogs/ext/prometheus.py
@@ -45,7 +45,7 @@ class GuildCollector:
         self.users = Gauge(f"{METRIC_PREFIX}users", "Total users")
 
     def _get_stats(self) -> GuildCount:
-        users = len(self.bot.users)
+        users = 0
         text = 0
         voice = 0
         guilds = 0
@@ -53,6 +53,9 @@ class GuildCollector:
             guilds += 1
             if guild.unavailable:
                 continue
+
+            users += guild.member_count or 0
+
             for channel in guild.channels:
                 if isinstance(channel, discord.TextChannel):
                     text += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ discord-ext-menus @ git+https://github.com/Rapptz/discord-ext-menus@8686b5d1bbc1
 python-dateutil>=2.9.0,<3
 msgspec>=0.18.6,<1
 pygit2>=1.14.1,<2
-psutil>=5.9.8<6
+psutil>=5.9.8,<6
 prometheus-client>=0.20.0,<1
 prometheus-async>=22.2.0,<23
 jishaku>=2.5.2,<3


### PR DESCRIPTION
# Summary

This PR aims to fix the inaccuracy when it came to sending how much total users that Catherine-Chan can see. Due to `Intents.members` being disabled, it always returns 1. But this method does actually count all of the users without having `Intents.members` enabled. 

## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR