### PR TITLE
Improve Catherine-Chan's error handlers

### DIFF
--- a/bot/libs/ui/pride_profiles/views.py
+++ b/bot/libs/ui/pride_profiles/views.py
@@ -1,7 +1,7 @@
 import asyncpg
 import discord
 from libs.utils import CatherineView
-from libs.utils.embeds import ErrorEmbed, SuccessEmbed
+from libs.utils.embeds import ErrorEmbed, SuccessEmbed, TimeoutEmbed
 
 from .selects import SelectPrideCategory
 
@@ -43,7 +43,7 @@ class DeleteProfileView(CatherineView):
     async def on_timeout(self) -> None:
         if self.original_response and not self.triggered.is_set():
             await self.original_response.edit(
-                embed=self.build_timeout_embed(), view=None, delete_after=15.0
+                embed=TimeoutEmbed(), view=None, delete_after=15.0
             )
 
     @discord.ui.button(

--- a/bot/libs/ui/tonetags/views.py
+++ b/bot/libs/ui/tonetags/views.py
@@ -5,7 +5,7 @@ from typing import Optional
 import asyncpg
 import discord
 from libs.cog_utils.tonetags import parse_tonetag
-from libs.utils import CatherineView, ErrorEmbed, SuccessEmbed
+from libs.utils import CatherineView, ErrorEmbed, SuccessEmbed, TimeoutEmbed
 
 NO_CONTROL_MSG = "This menu cannot be controlled by you, sorry!"
 
@@ -27,7 +27,7 @@ class DeleteTagView(CatherineView):
     async def on_timeout(self) -> None:
         if self.original_response and not self.triggered.is_set():
             await self.original_response.edit(
-                embed=self.build_timeout_embed(), view=None, delete_after=15.0
+                embed=TimeoutEmbed(), view=None, delete_after=15.0
             )
 
     @discord.ui.button(

--- a/bot/libs/utils/embeds.py
+++ b/bot/libs/utils/embeds.py
@@ -1,3 +1,5 @@
+import traceback
+
 import discord
 
 
@@ -30,6 +32,24 @@ class ErrorEmbed(discord.Embed):
             "Uh oh! It seems like the command ran into an issue! For support, please visit [Catherine-Chan's Support Server](https://discord.gg/ns3e74frqn) to get help!",
         )
         super().__init__(**kwargs)
+        self.set_footer(text="Happened At")
+        self.timestamp = discord.utils.utcnow()
+
+
+class FullErrorEmbed(ErrorEmbed):
+    def __init__(self, error: Exception, **kwargs):
+        kwargs.setdefault("description", self._format_description(error))
+        super().__init__(**kwargs)
+
+    def _format_description(self, error: Exception) -> str:
+        error_traceback = "\n".join(traceback.format_exception_only(type(error), error))
+        desc = f"""
+        Uh oh! It seems like the command ran into an issue! For support, please visit [Catherine-Chan's Support Server](https://discord.gg/ns3e74frqn) to get help!
+        
+        **Error**:
+        ```{error_traceback}```
+        """
+        return desc
 
 
 class ConfirmEmbed(discord.Embed):

--- a/bot/libs/utils/embeds.py
+++ b/bot/libs/utils/embeds.py
@@ -52,15 +52,6 @@ class FullErrorEmbed(ErrorEmbed):
         return desc
 
 
-class ConfirmEmbed(discord.Embed):
-    """Kumiko's custom confirm embed"""
-
-    def __init__(self, **kwargs):
-        kwargs.setdefault("color", discord.Color.from_rgb(255, 191, 0))
-        kwargs.setdefault("title", "Are you sure?")
-        super().__init__(**kwargs)
-
-
 class TimeoutEmbed(discord.Embed):
     """Timed out embed"""
 
@@ -70,4 +61,13 @@ class TimeoutEmbed(discord.Embed):
         kwargs.setdefault(
             "description", "Timed out waiting for a response. Cancelling action."
         )
+        super().__init__(**kwargs)
+
+
+class ConfirmEmbed(discord.Embed):
+    """Kumiko's custom confirm embed"""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("color", discord.Color.from_rgb(255, 191, 0))
+        kwargs.setdefault("title", "Are you sure?")
         super().__init__(**kwargs)

--- a/bot/libs/utils/modal.py
+++ b/bot/libs/utils/modal.py
@@ -3,7 +3,7 @@ import traceback
 import discord
 from discord.utils import utcnow
 
-from .embeds import ErrorEmbed
+from .embeds import ErrorEmbed, FullErrorEmbed
 
 NO_CONTROL_MSG = "This modal cannot be controlled by you, sorry!"
 
@@ -39,7 +39,5 @@ class CatherineModal(discord.ui.Modal):
     async def on_error(
         self, interaction: discord.Interaction, error: Exception, /
     ) -> None:
-        await interaction.response.send_message(
-            embed=produce_error_embed(error), ephemeral=True
-        )
+        await interaction.response.send_message(embed=FullErrorEmbed(error))
         self.stop()

--- a/bot/libs/utils/modal.py
+++ b/bot/libs/utils/modal.py
@@ -1,31 +1,22 @@
-import traceback
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import discord
-from discord.utils import utcnow
 
-from .embeds import ErrorEmbed, FullErrorEmbed
+from .embeds import FullErrorEmbed
+
+if TYPE_CHECKING:
+    from catherinecore import Catherine
 
 NO_CONTROL_MSG = "This modal cannot be controlled by you, sorry!"
-
-
-def produce_error_embed(error: Exception) -> ErrorEmbed:
-    error_traceback = "\n".join(traceback.format_exception_only(type(error), error))
-    embed = ErrorEmbed()
-    embed.description = f"""
-    Uh oh! It seems like the modal ran into an issue! For support, please visit [Catherine-Chan's Support Server](https://discord.gg/ns3e74frqn) to get help!
-    
-    **Error**:
-    ```{error_traceback}```
-    """
-    embed.set_footer(text="Happened At")
-    embed.timestamp = utcnow()
-    return embed
 
 
 class CatherineModal(discord.ui.Modal):
     def __init__(self, interaction: discord.Interaction, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.interaction = interaction
+        self.bot: Catherine = interaction.client  # type: ignore
 
     async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
         if interaction.user and interaction.user.id in (
@@ -39,6 +30,11 @@ class CatherineModal(discord.ui.Modal):
     async def on_error(
         self, interaction: discord.Interaction, error: Exception, /
     ) -> None:
+        self.bot.logger.exception(
+            "Ignoring modal exception from %s: ",
+            self.__class__.__name__,
+            exc_info=error,
+        )
         await interaction.response.send_message(
             embed=FullErrorEmbed(error), ephemeral=True
         )

--- a/bot/libs/utils/modal.py
+++ b/bot/libs/utils/modal.py
@@ -39,5 +39,7 @@ class CatherineModal(discord.ui.Modal):
     async def on_error(
         self, interaction: discord.Interaction, error: Exception, /
     ) -> None:
-        await interaction.response.send_message(embed=FullErrorEmbed(error))
+        await interaction.response.send_message(
+            embed=FullErrorEmbed(error), ephemeral=True
+        )
         self.stop()

--- a/bot/libs/utils/view.py
+++ b/bot/libs/utils/view.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import discord
 
 from .embeds import FullErrorEmbed, TimeoutEmbed
+
+if TYPE_CHECKING:
+    from catherinecore import Catherine
 
 NO_CONTROL_MSG = "This view cannot be controlled by you, sorry!"
 
@@ -19,6 +24,7 @@ class CatherineView(discord.ui.View):
         self.interaction = interaction
         self.original_response: Optional[discord.InteractionMessage]
         self.triggered = asyncio.Event()
+        self.bot: Catherine = interaction.client  # type: ignore
 
     async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
         if interaction.user and interaction.user.id in (
@@ -42,6 +48,9 @@ class CatherineView(discord.ui.View):
         item: discord.ui.Item[Any],
         /,
     ) -> None:
+        self.bot.logger.exception(
+            "Ignoring view exception from %s: ", self.__class__.__name__, exc_info=error
+        )
         await interaction.response.send_message(
             embed=FullErrorEmbed(error), ephemeral=True
         )

--- a/bot/libs/utils/view.py
+++ b/bot/libs/utils/view.py
@@ -42,5 +42,7 @@ class CatherineView(discord.ui.View):
         item: discord.ui.Item[Any],
         /,
     ) -> None:
-        await interaction.response.send_message(embed=FullErrorEmbed(error))
+        await interaction.response.send_message(
+            embed=FullErrorEmbed(error), ephemeral=True
+        )
         self.stop()

--- a/bot/libs/utils/view.py
+++ b/bot/libs/utils/view.py
@@ -1,29 +1,11 @@
 import asyncio
-import traceback
 from typing import Any, Optional
 
 import discord
-from discord.utils import utcnow
 
-from .embeds import ErrorEmbed
+from .embeds import FullErrorEmbed, TimeoutEmbed
 
 NO_CONTROL_MSG = "This view cannot be controlled by you, sorry!"
-
-
-def make_error_embed(error: Exception, item: discord.ui.Item[Any]) -> ErrorEmbed:
-    error_traceback = "\n".join(traceback.format_exception_only(type(error), error))
-    embed = ErrorEmbed()
-    embed.description = f"""
-    Uh oh! It seems like the view ran into an issue! For support, please visit [Catherine-Chan's Support Server](https://discord.gg/ns3e74frqn) to get help!
-    
-    **Item**: `{item.__class__.__name__}`
-    
-    **Error**:
-    ```{error_traceback}```
-    """
-    embed.set_footer(text="Happened At")
-    embed.timestamp = utcnow()
-    return embed
 
 
 class CatherineView(discord.ui.View):
@@ -38,12 +20,6 @@ class CatherineView(discord.ui.View):
         self.original_response: Optional[discord.InteractionMessage]
         self.triggered = asyncio.Event()
 
-    def build_timeout_embed(self) -> ErrorEmbed:
-        embed = ErrorEmbed()
-        embed.title = "\U00002757 Timed Out"
-        embed.description = "Timed out waiting for a response. Cancelling action."
-        return embed
-
     async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
         if interaction.user and interaction.user.id in (
             self.interaction.client.application.owner.id,  # type: ignore
@@ -56,7 +32,7 @@ class CatherineView(discord.ui.View):
     async def on_timeout(self) -> None:
         if self.original_response:
             await self.original_response.edit(
-                embed=self.build_timeout_embed(), view=None, delete_after=15.0
+                embed=TimeoutEmbed(), view=None, delete_after=15.0
             )
 
     async def on_error(
@@ -66,7 +42,5 @@ class CatherineView(discord.ui.View):
         item: discord.ui.Item[Any],
         /,
     ) -> None:
-        await interaction.response.send_message(
-            embed=make_error_embed(error, item), ephemeral=True
-        )
+        await interaction.response.send_message(embed=FullErrorEmbed(error))
         self.stop()


### PR DESCRIPTION
# Summary

This PR focuses on improving the error handlers used by Catherine-Chan. This time around, I've used an design similar to Rodhaj, which has worked in the past. There are error cases that just need to be handled locally but should instead now cover more use cases now.

## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR