### PR TITLE
Fix exception violations with pronouns tester

### DIFF
--- a/bot/cogs/pronouns.py
+++ b/bot/cogs/pronouns.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
 
-import asyncpg
 import discord
 import msgspec
 import orjson
@@ -182,17 +181,11 @@ class SuggestPronounsExamplesModal(CatherineModal, title="Suggest an example"):
                 example_id = await connection.fetchval(
                     query, interaction.user.id, self.sentence.value
                 )
-            except asyncpg.UniqueViolationError:
+            except Exception as e:
                 await tr.rollback()
                 await interaction.response.send_message(
-                    "The sentence you are trying to suggest already exists!",
+                    f"Suggestion entirely failed for unknown reason ({str(e)})",
                     ephemeral=True,
-                )
-                return
-            except Exception:
-                await tr.rollback()
-                await interaction.response.send_message(
-                    "Suggestion entirely failed for unknown reason", ephemeral=True
                 )
             else:
                 await tr.commit()


### PR DESCRIPTION
# Summary

When I deployed v1-alpha to prod and was testing it, the pronouns suggest example didn't work as it literally rejected all entries saying that it is "unique" and violates something. So in order to fix it, I decided to go ahead and remove it entirely, and it worked. In order to diagnosis future errors, the exception block now shows the error.

## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR