### PR TITLE
Prevent unsanitized queries from creating Cloudflare errors

### DIFF
--- a/bot/cogs/dictionary.py
+++ b/bot/cogs/dictionary.py
@@ -345,7 +345,7 @@ class Dictionary(commands.GroupCog, name="dictionary"):
             # If people start using this for pronouns, then a generator shows up
             # so that's in case this happens
             if r.status == 204:
-                await interaction.response.send_message("Did you just insert pronouns?")
+                await interaction.response.send_message("Uhhhhhhhhhhhh what")
                 return
 
             data = await r.json(loads=self.decoder.decode)

--- a/bot/cogs/dictionary.py
+++ b/bot/cogs/dictionary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Optional
 
+import aiohttp
 import discord
 import msgspec
 from discord import app_commands
@@ -10,7 +11,6 @@ from discord.ext import commands, menus
 from libs.utils import Embed
 from libs.utils.pages import CatherinePages
 from yarl import URL
-import aiohttp
 
 if TYPE_CHECKING:
     from catherinecore import Catherine

--- a/bot/cogs/dictionary.py
+++ b/bot/cogs/dictionary.py
@@ -305,7 +305,10 @@ class Dictionary(commands.GroupCog, name="dictionary"):
     async def _handle_invalid_response(
         self, interaction: discord.Interaction, error: app_commands.CommandInvokeError
     ) -> None:
-        if isinstance(error.original, aiohttp.ContentTypeError):
+        if (
+            isinstance(error.original, aiohttp.ContentTypeError)
+            and error.original.status == 403
+        ):
             await interaction.response.send_message(
                 "Unable to validate forbidden query"
             )

--- a/bot/cogs/dictionary.py
+++ b/bot/cogs/dictionary.py
@@ -303,10 +303,11 @@ class Dictionary(commands.GroupCog, name="dictionary"):
         return f"[{author}]({author_link})"
 
     async def _handle_invalid_response(
-        self, interaction: discord.Interaction, error: app_commands.CommandInvokeError
+        self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
         if (
-            isinstance(error.original, aiohttp.ContentTypeError)
+            isinstance(error, app_commands.CommandInvokeError)
+            and isinstance(error.original, aiohttp.ContentTypeError)
             and error.original.status == 403
         ):
             await interaction.response.send_message(
@@ -380,22 +381,19 @@ class Dictionary(commands.GroupCog, name="dictionary"):
     async def on_terms_error(
         self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
-        if isinstance(error, app_commands.CommandInvokeError):
-            await self._handle_invalid_response(interaction, error)
+        await self._handle_invalid_response(interaction, error)
 
     @nouns.error
     async def on_nouns_error(
         self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
-        if isinstance(error, app_commands.CommandInvokeError):
-            await self._handle_invalid_response(interaction, error)
+        await self._handle_invalid_response(interaction, error)
 
     @inclusive.error
     async def on_inclusive_error(
         self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
-        if isinstance(error, app_commands.CommandInvokeError):
-            await self._handle_invalid_response(interaction, error)
+        await self._handle_invalid_response(interaction, error)
 
 
 async def setup(bot: Catherine) -> None:

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 - Use proper type checking imports (https://github.com/No767/Catherine-Chan/pull/216)
 - Fix exception violations with pronouns tester (https://github.com/No767/Catherine-Chan/pull/212)
 - Migrate from Bandit, Black, Autoflake and Isort to Ruff (https://github.com/No767/Catherine-Chan/pull/218, https://github.com/No767/Catherine-Chan/pull/223)
+- Prevent unsanitized queries from creating Cloudflare errors (https://github.com/No767/Catherine-Chan/pull/226)
 
 ## ✨ Additions
 


### PR DESCRIPTION
# Summary

This actually has been a bug for a long time, but I haven't noticed this. Within the dictionary commands, you can send an invalid query (e.g. for SQL injection), and Cloudflare would block it. This would result in a content type being HTML, and a HTTP 403 status code would be sent from Discord. There were some folks who abused this to try and get Catherine-Chan to crash thinking that error handling was not implemented and an attempt to block the event loop (which never happened as Catherine-Chan uses aiohttp for HTTP requests, not the `requests` library)

## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR