### PR TITLE
Ignore all `aiohttp.ContentTypeError` occurrences

### DIFF
--- a/bot/libs/utils/tree.py
+++ b/bot/libs/utils/tree.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import aiohttp
 import discord
 from discord import app_commands
 
@@ -71,11 +72,16 @@ class CatherineCommandTree(app_commands.CommandTree):
                     interaction.command.qualified_name,  # type: ignore
                     exc_info=original,
                 )
-                if interaction.response.is_done():
-                    await interaction.followup.send(
-                        embed=FullErrorEmbed(error), ephemeral=True
-                    )
+
+                # Basically just ignore all content type errors for responses
+                # Since we already have them printed to stderr, it makes no sense to send a response back to the user when a response is already sent.
+                # In this case, it actually does more harm by giving the attackers more information than less.
+                if (
+                    isinstance(original, aiohttp.ContentTypeError)
+                    and original.status == 0
+                ):
                     return
+
                 await interaction.response.send_message(
                     embed=FullErrorEmbed(error), ephemeral=True
                 )

--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@
 - Use proper type checking imports (https://github.com/No767/Catherine-Chan/pull/216)
 - Fix exception violations with pronouns tester (https://github.com/No767/Catherine-Chan/pull/212)
 - Migrate from Bandit, Black, Autoflake and Isort to Ruff (https://github.com/No767/Catherine-Chan/pull/218, https://github.com/No767/Catherine-Chan/pull/223)
-- Prevent unsanitized queries from creating Cloudflare errors (https://github.com/No767/Catherine-Chan/pull/226, https://github.com/No767/Catherine-Chan/pull/227)
+- Prevent unsanitized queries from creating Cloudflare errors (https://github.com/No767/Catherine-Chan/pull/226, https://github.com/No767/Catherine-Chan/pull/227, https://github.com/No767/Catherine-Chan/pull/228)
 
 ## ✨ Additions
 


### PR DESCRIPTION
# Summary

Basically ignore all `aiohttp.ContentTypeError` occurrences within the tree. This way, we still get a response back for the user saying that we can't parse their query, and it's emitted into stderr for tracking purposes. But we don't send back another response with the usual `FullEmbedError` contents so this hides the invalid query and doesn't give more information than necessary.


## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR