### PR TITLE
Repin `msgspec` to release versions and ignore reoccurring Pyright error

### DIFF
--- a/bot/cogs/meta.py
+++ b/bot/cogs/meta.py
@@ -82,7 +82,7 @@ class Meta(commands.Cog):
         # For Kumiko, it's done differently
         # R. Danny's way of doing it is probably close enough anyways
         memory_usage = self.process.memory_full_info().uss / 1024**2
-        cpu_usage = self.process.cpu_percent() / psutil.cpu_count()
+        cpu_usage = self.process.cpu_percent() / psutil.cpu_count() # type: ignore # Pyright is still complaining
 
         revisions = self.get_last_commits()
         embed = Embed()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ winloop>=0.1.1,<1 ; sys_platform == "win32"
 asyncpg>=0.29.0,<1
 discord-ext-menus @ git+https://github.com/Rapptz/discord-ext-menus@8686b5d1bbc1d3c862292eb436ab630d6e9c9b53
 python-dateutil>=2.9.0,<3
-msgspec @ git+https://github.com/jcrist/msgspec@e06e9c9fbacf372f71afbb41e3b772bf94d753e6
+msgspec>=0.19.0,<1
 pygit2>=1.14.1,<2
 psutil>=6.0.0,<7
 prometheus-client>=0.20.0,<1


### PR DESCRIPTION
# Summary

4 days ago, msgspec finally released a proper version that has a Python 3.13 build. We no longer need to install by git now. Also ignores an error in the `meta` cog that Pyright complains about incorrect results.

## Types of changes

What types of changes does your code introduce to Catherine-Chan
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR